### PR TITLE
Implement DESTDIR support in make install-Targets

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -13,11 +13,11 @@ spec:
 	@sed "s\\_BIN_\\$(BIN)\\g ; s\\_VER_\\$(VER)\\g; s\\_SBIN_\\$(SBIN)\\g; s\\_SEC_\\$(MAN_SEC)\\g" < spec.tmpl > $(BIN)-$(VER).spec 
 
 install:
-	mkdir -m 755 -p  $(HOMEDIR)/block $(HOMEDIR)/bin $(CONFDIR)
-	echo \|$(BINDIR)/$(BIN) > $(HOMEDIR)/.forward
-	install -m 644 header.txt $(HOMEDIR)
-	install -m 644 footer.txt $(HOMEDIR)
-	install -m 600 gnarwl.cfg $(CONFDIR)
-	cat badheaders.txt | $(SBINDIR)/$(SBIN) -a $(HOMEDIR)/badheaders.db
-	cat blacklist.txt | $(SBINDIR)/$(SBIN) -a $(HOMEDIR)/blacklist.db
+	mkdir -m 755 -p  $(DESTDIR)$(HOMEDIR)/block $(DESTDIR)$(HOMEDIR)/bin $(DESTDIR)$(CONFDIR)
+	echo \|$(BINDIR)/$(BIN) > $(DESTDIR)$(HOMEDIR)/.forward
+	install -m 644 header.txt $(DESTDIR)$(HOMEDIR)
+	install -m 644 footer.txt $(DESTDIR)$(HOMEDIR)
+	install -m 600 gnarwl.cfg $(DESTDIR)$(CONFDIR)
+	cat badheaders.txt | $(DESTDIR)$(SBINDIR)/$(SBIN) -a $(DESTDIR)$(HOMEDIR)/badheaders.db
+	cat blacklist.txt | $(DESTDIR)$(SBINDIR)/$(SBIN) -a $(DESTDIR)$(HOMEDIR)/blacklist.db
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -13,19 +13,19 @@ manpage:
 
 
 install:
-	mkdir -m 755 -p $(DOCDIR) $(MANDIR)/man$(MAN_SEC)
-	install -m 644 $(BIN).$(MAN_SEC) $(MANDIR)/man$(MAN_SEC)
-	install -m 644 $(SBIN).$(MAN_SEC) $(MANDIR)/man$(MAN_SEC)
-	install -m 644 FAQ $(DOCDIR)
-	install -m 644 LICENSE $(DOCDIR)
-	install -m 644 AUTHORS $(DOCDIR)
-	install -m 644 INSTALL $(DOCDIR)
-	install -m 644 ISPEnv.schema $(DOCDIR)
-	install -m 644 ISPEnv2.schema $(DOCDIR)
-	install -m 644 example.ldif $(DOCDIR)
-	install -m 644 HISTORY $(DOCDIR)
-	install -m 644 README $(DOCDIR)
-	gzip -f -9 $(DOCDIR)/FAQ
-	gzip -f -9 $(DOCDIR)/HISTORY
-	gzip -f -9 $(MANDIR)/man$(MAN_SEC)/$(BIN).$(MAN_SEC)
-	gzip -f -9 $(MANDIR)/man$(MAN_SEC)/$(SBIN).$(MAN_SEC)
+	mkdir -m 755 -p $(DESTDIR)$(DOCDIR) $(DESTDIR)$(MANDIR)/man$(MAN_SEC)
+	install -m 644 $(BIN).$(MAN_SEC) $(DESTDIR)$(MANDIR)/man$(MAN_SEC)
+	install -m 644 $(SBIN).$(MAN_SEC) $(DESTDIR)$(MANDIR)/man$(MAN_SEC)
+	install -m 644 FAQ $(DESTDIR)$(DOCDIR)
+	install -m 644 LICENSE $(DESTDIR)$(DOCDIR)
+	install -m 644 AUTHORS $(DESTDIR)$(DOCDIR)
+	install -m 644 INSTALL $(DESTDIR)$(DOCDIR)
+	install -m 644 ISPEnv.schema $(DESTDIR)$(DOCDIR)
+	install -m 644 ISPEnv2.schema $(DESTDIR)$(DOCDIR)
+	install -m 644 example.ldif $(DESTDIR)$(DOCDIR)
+	install -m 644 HISTORY $(DESTDIR)$(DOCDIR)
+	install -m 644 README $(DESTDIR)$(DOCDIR)
+	gzip -f -9 $(DESTDIR)$(DOCDIR)/FAQ
+	gzip -f -9 $(DESTDIR)$(DOCDIR)/HISTORY
+	gzip -f -9 $(DESTDIR)$(MANDIR)/man$(MAN_SEC)/$(BIN).$(MAN_SEC)
+	gzip -f -9 $(DESTDIR)$(MANDIR)/man$(MAN_SEC)/$(SBIN).$(MAN_SEC)

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ clean:
 	rm -f DEADJOE *.o *~ $(BIN) $(SBIN)
 
 install:
-	mkdir -m 755 -p $(BINDIR) $(SBINDIR)
-	install -m 755 -s $(BIN) $(BINDIR)
-	install -m 755 -s $(SBIN) $(SBINDIR)
+	mkdir -m 755 -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(SBINDIR)
+	install -m 755 -s $(BIN) $(DESTDIR)$(BINDIR)
+	install -m 755 -s $(SBIN) $(DESTDIR)$(SBINDIR)
 


### PR DESCRIPTION
This eases the burden for package maintainers where the build system
needs to install the files in a temporary directory for packaging.