### PR TITLE
Add deref option for LDAP alias dereferencing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Improvements
 *   New config option *ca_cert* allow specifying CA certificate when ldaps or 
     StartTLS is used.
 *   New config option *starttls*.
+*   New config option *deref* allows control of LDAP alias dereferencing.

--- a/doc/gnarwl.man
+++ b/doc/gnarwl.man
@@ -194,6 +194,9 @@ Specifies what to send to the syslog. A higher loglevel
 automatically includes all lower loglevels (see section syslog for more 
 information).
 
+.IP "deref <never|search|find|always>"
+Controls what LDAP alias dereferencing will be performed. Default is "find".
+
 .SH SYSLOG
 Since 
 .B gnarwl

--- a/src/config.c
+++ b/src/config.c
@@ -192,6 +192,14 @@ void putEntry(char* key, char* val) {
     return;
   }
   
+  if (!strcasecmp(key,"deref")) {
+    if (!strcasecmp(val,"never")) cfg.deref=LDAP_DEREF_NEVER;
+    if (!strcasecmp(val,"search")) cfg.deref=LDAP_DEREF_SEARCHING;
+    if (!strcasecmp(val,"find")) cfg.deref=LDAP_DEREF_FINDING;
+    if (!strcasecmp(val,"always")) cfg.deref=LDAP_DEREF_ALWAYS;
+    return;
+  }
+
   syslog(LOG_MAIL|LOG_WARNING,"WARN/CFG Unknown config directive: %s",key);
 }
 
@@ -226,6 +234,7 @@ void setDefaults(void) {
   cpyStr(&cfg.recv_header[0],"to");
   cpyStr(&cfg.recv_header[1],"cc");
   if (cfg.macro_attr==NULL || cfg.macro_name==NULL) oom();
+  cfg.deref=LDAP_DEREF_FINDING;
 }
 
 void readConf(char *cfile) {

--- a/src/config.c
+++ b/src/config.c
@@ -234,7 +234,7 @@ void setDefaults(void) {
   cpyStr(&cfg.recv_header[0],"to");
   cpyStr(&cfg.recv_header[1],"cc");
   if (cfg.macro_attr==NULL || cfg.macro_name==NULL) oom();
-  cfg.deref=LDAP_DEREF_FINDING;
+  cfg.deref=LDAP_DEREF_NEVER;
 }
 
 void readConf(char *cfile) {

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ struct conf {
   int maxmail;		// max number of recepients allowed
   int maxheader;	// max number of header lines allowed in mail
   int umask;		// file creation mask for db files
+  int deref;		// When to follow LDAP aliases
 };
 
 /**

--- a/src/dbaccess.c
+++ b/src/dbaccess.c
@@ -196,6 +196,7 @@ void dbConnect() {
   }
 
   ldap_set_option(ldcon, LDAP_OPT_PROTOCOL_VERSION, &cfg.protver);
+  ldap_set_option(ldcon, LDAP_OPT_DEREF, &cfg.deref);
 
   if (cfg.starttls) {
     rc = ldap_start_tls_s(ldcon, NULL, NULL);


### PR DESCRIPTION
This allows the user to control what LDAP alias dereferencing is performed. (The best description of the four options I've found is here: https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.1.0/com.ibm.zos.v2r1.glpa200/glpa200_Dereferencing_during_search.htm)