### PR TITLE
Fix compilation with ld --as-needed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,8 +7,8 @@ catch:
 all: clean compile
 
 compile: $(OBJ) $(SOBJ)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $(BIN) gnarwl.c $(OBJ)
-	$(CC) $(CFLAGS) $(LFLAGS) -o $(SBIN) damnit.c $(SOBJ)
+	$(CC) $(CFLAGS) -o $(BIN) gnarwl.c $(OBJ) $(LFLAGS)
+	$(CC) $(CFLAGS) -o $(SBIN) damnit.c $(SOBJ) $(LFLAGS)
 
 clean:
 	rm -f DEADJOE *.o *~ $(BIN) $(SBIN)


### PR DESCRIPTION
Patch submitted to Debian BTS by Daniel Holbach to fix compilation on distributions where the linker defaults to --as-needed (i.e. Ubuntu).

The same patch is also in use on OpenSuSE build service (https://build.opensuse.org/package/view_file/server:mail/gnarwl/gnarwl-fix-gcc46.patch?expand=1)