### PR TITLE
WIP: Fix autoreconf/autoheader breaking compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 AC_INIT()
 AC_CONFIG_HEADERS(conf.h)
+AH_TOP([#include "static.h"])
 AC_CONFIG_FILES(Makefile)
 
 # Checks for programs.
@@ -30,8 +31,8 @@ AC_CHECK_FUNCS([ldap_set_option])
 
 AC_CHECK_FUNCS([iconv])
 
-AC_DEFINE_UNQUOTED(UMASK,$permmask)
-AC_DEFINE_UNQUOTED(MAXLINE,$maxline)
-AC_DEFINE_UNQUOTED(DEFAULT_MTA,$mta)
+AC_DEFINE_UNQUOTED(UMASK,[$permmask], [File creation mask for database files])
+AC_DEFINE_UNQUOTED(MAXLINE,[$maxline], [Maximum input buffer line length])
+AC_DEFINE_UNQUOTED(DEFAULT_MTA,[$mta], [MTA to use])
 
 AC_OUTPUT

--- a/static.h
+++ b/static.h
@@ -1,0 +1,38 @@
+/* These #define have been taken from conf.h.in which is supposed to
+ * be autocreated by autoheader. The settings below are never defined
+ * anywhere and were probably added manually to conf.h.in, which made
+ * the build break any time autoreconf was called
+ */
+
+#define TIMEFACTOR 3600
+#define LDAPQUERY_MAXWAIT 10
+#define DEFAULT_SERVER "localhost"
+#define DEFAULT_QFILTER "(&(mail=$recepient)(vacationActive=TRUE)"
+#define DEFAULT_MES "vacationInfo"
+#define DEFAULT_BASE ""
+#define DEFAULT_EXPIRE 48
+#define DEFAULT_MAIL_LIMIT 256
+#define DEFAULT_MAP_SENDER "$sender"
+#define DEFAULT_MAP_RECEIVER "$recepient"
+#define DEFAULT_MAP_SUBJECT "$subject"
+#define LDAP_PROTOCOL_DETECT 0
+#define LDAP_CHARSET "UTF-8"
+#define LVL_CRIT 0
+#define LVL_WARN 1
+#define LVL_INFO 2
+#define LVL_DEBUG 3
+
+#define TRUE 1
+#define FALSE 0
+
+#ifndef BLOCKDIR
+#define BLOCKDIR "/tmp"
+#endif
+
+#ifndef CFGFILE
+#define CFGFILE "/etc/gnarwl.cfg"
+#endif
+#ifndef VERSION
+#define VERSION " <unknown>"
+#endif
+


### PR DESCRIPTION
When autoreconf is called to generate all the supposedly autogenerated
files the build breaks. First, an incompatibility with newer autoheader
versions is encountered

autoheader: warning: missing template: DEFAULT_MTA
autoheader: Use AC_DEFINE([DEFAULT_MTA], [], [Description])
autoheader: warning: missing template: MAXLINE
autoheader: warning: missing template: UMASK
autoreconf: /usr/bin/autoheader failed with exit status: 1

Then as far as I understand conf.h.in is supposedly generated from
all the AC_DEFINE*/AC_CHECK* macros in configure.ac. But it obviously
isn't, there are a lot of static #define statements in there that
are not defined anywhere else.

Fix this by putting all those static settings into static.h, then
include that in conf.h.in with AH_TOP([#include "static.h"])